### PR TITLE
Fix unbounded MCP session map memory leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,15 +54,59 @@ async function startHttpServer() {
     res.json({ status: 'ok' });
   });
 
-  const sessions = new Map<string, StreamableHTTPServerTransport>();
+  interface Session {
+    transport: StreamableHTTPServerTransport;
+    server: McpServer;
+    lastActivity: number;
+  }
+
+  const sessions = new Map<string, Session>();
+  const SESSION_TTL_MS = 10 * 60 * 1000; // evict a session after 10 min idle
+  const MAX_SESSIONS = 100; // hard ceiling on concurrent sessions
+  const SWEEP_INTERVAL_MS = 60 * 1000;
+
+  function closeSession(id: string): void {
+    const session = sessions.get(id);
+    if (!session) return;
+    sessions.delete(id);
+    // Dispose the transport and its McpServer so the per-session tool
+    // registrations can be garbage collected.
+    void session.transport.close().catch(() => {});
+    void session.server.close().catch(() => {});
+  }
+
+  // Backstop for clients that disconnect without sending a session-terminating
+  // DELETE (their onclose never fires): sweep idle sessions so the map cannot
+  // grow unbounded.
+  const sweep = setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of sessions) {
+      if (now - session.lastActivity > SESSION_TTL_MS) closeSession(id);
+    }
+  }, SWEEP_INTERVAL_MS);
+  sweep.unref(); // don't keep the event loop alive
 
   app.all('/mcp', authMiddleware, async (req, res) => {
     const existingSessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (existingSessionId && sessions.has(existingSessionId)) {
-      const transport = sessions.get(existingSessionId)!;
-      await transport.handleRequest(req, res, req.body);
+      const session = sessions.get(existingSessionId)!;
+      session.lastActivity = Date.now();
+      await session.transport.handleRequest(req, res, req.body);
       return;
+    }
+
+    // Evict the least-recently-used session if at capacity.
+    if (sessions.size >= MAX_SESSIONS) {
+      let oldestId: string | undefined;
+      let oldest = Infinity;
+      for (const [id, session] of sessions) {
+        if (session.lastActivity < oldest) {
+          oldest = session.lastActivity;
+          oldestId = id;
+        }
+      }
+      if (oldestId) closeSession(oldestId);
     }
 
     const transport = new StreamableHTTPServerTransport({
@@ -75,7 +119,11 @@ async function startHttpServer() {
 
     const newSessionId = res.getHeader('mcp-session-id') as string | undefined;
     if (newSessionId) {
-      sessions.set(newSessionId, transport);
+      sessions.set(newSessionId, {
+        transport,
+        server: sessionServer,
+        lastActivity: Date.now(),
+      });
       transport.onclose = () => sessions.delete(newSessionId);
     }
   });


### PR DESCRIPTION
Closes #10.

## Problem

`startHttpServer` stored every MCP session in an in-memory `Map` whose only cleanup path was `transport.onclose`. Streamable-HTTP clients routinely disconnect without sending a session-terminating `DELETE`, so `onclose` never fires and each abandoned session leaks its transport **plus a full `McpServer`** (all six tool modules). Memory climbed from ~50 MB to **2.3 GB** over ~26 days (avg ~1 GB) — ~$10/mo on Railway, ~73% of the org's Railway usage.

## Fix

Bound the session store in `src/index.ts`:

- Track `lastActivity` per session and bump it on every request.
- A 60s `setInterval` **sweep** evicts sessions idle longer than `SESSION_TTL_MS` (10 min) — the backstop for clients that never send `DELETE`. The interval is `.unref()`'d so it can't keep the event loop alive.
- `MAX_SESSIONS` (100) hard ceiling with **LRU eviction** before admitting a new session.
- `closeSession()` disposes **both** the transport and its `McpServer`, so the per-session tool registrations are garbage-collected.

Well-behaved clients that send `DELETE` still terminate immediately via the existing `onclose` path; the sweep only catches the ones that don't.

## Verification

- `npm run build` (tsc) — passes clean (confirms `transport.close()` / `McpServer.close()` types).
- Boot smoke: built `dist/index.js` starts in stdio mode without error.
- Expected steady-state after deploy: ~50–100 MB (down from ~1 GB avg), Railway cost ~$10/mo → ~$1/mo. Worth confirming on the Railway metrics a few days post-merge.

## Note

The production service was **redeployed 2026-07-24** as an interim reset (2.3 GB → ~50 MB). That's a stopgap; merging this makes it permanent. Merging to `master` will auto-deploy via the GitHub-connected service.