### PR TITLE
feat: migrate to MCP SDK v2 and drop the session layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,15 @@ No test suite — verify changes by building and manually testing against the OC
 
 Two-layer separation: `tools/` files define MCP tool schemas and handlers, `queries/` files hold raw GraphQL strings. `graphql.ts` is the single point of contact with the OC API — all tools call `gql<T>(query, variables)`.
 
-Each tool domain has a `register*Tools(server: McpServer)` function called from `createServer()` in `index.ts`. The server factory is called once per MCP session (not once per request).
+Each tool domain has a `register*Tools(server: McpServer)` function called from `createServer()` in `index.ts`. **The server factory is called once per HTTP request** (it used to be once per session, before the SDK v2 migration).
 
-**Transport:** `index.ts` checks `process.env.PORT` — if set, runs Express with StreamableHTTPServerTransport (Railway); otherwise, runs StdioServerTransport (local dev). HTTP mode uses a session map keyed by `mcp-session-id` header, creating a fresh `McpServer` per session.
+**Transport:** `index.ts` checks `process.env.PORT` — if set, serves over HTTP via `createMcpExpressApp` + `createMcpHandler` + `toNodeHandler`; otherwise `serveStdio` (local dev). Both take a factory rather than a built server.
+
+**There is no session state.** Under the 2026-07-28 spec `Mcp-Session-Id` is retired ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)) and `createMcpHandler` builds a fresh `McpServer` per request. The old code kept an in-memory `Map` of transports keyed by that header, which meant sessions pinned to one container; **the service can now be scaled to more than one replica.** Do not reintroduce per-session state in this process without reading that through.
+
+**DNS rebinding protection is off.** `createMcpExpressApp` only auto-applies it for `127.0.0.1`/`localhost`/`::1`, and Railway needs `0.0.0.0`, so the server logs a warning about it on boot. That is expected and matches the pre-migration behaviour, which validated no hosts either. The gate on `/mcp` is the `API_KEY` Bearer check. Pass `allowedHosts` if that ever needs tightening.
+
+**Tool `inputSchema` still uses the deprecated raw-shape form** (`{ field: z.string() }`). v2 auto-wraps it and the types accept it, but they ask for `z.object({...})`. Tracked in #12.
 
 **Auth layers:** Two separate tokens — `OPEN_COLLECTIVE_TOKEN` (Personal Token for OC API, sent as `Personal-Token` header) and `API_KEY` (Bearer token for MCP client auth, checked in Express middleware). Stdio mode doesn't use `API_KEY`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/express": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "express": "^5.2.1",
         "zod": "^4.3.6"
       },
@@ -474,44 +476,67 @@
         "hono": "^4"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/express": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/express/-/express-2.0.0.tgz",
+      "integrity": "sha512-Snlr8j9FR9LcVvEJPF7qJ7d5zTL4Bes2dk7RcacN9eSZ7OLohwxqhEvWu1+UxELyScgLbLLOdeVEGdwKI1iwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cors": "^2.8.5"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "express": "^4.18.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
+        "hono": {
           "optional": true
-        },
-        "zod": {
-          "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@types/body-parser": {
@@ -623,39 +648,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/body-parser": {
@@ -775,20 +767,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -933,27 +911,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -997,46 +954,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1239,15 +1156,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1262,33 +1170,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
-    },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1411,15 +1292,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -1428,15 +1300,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1489,15 +1352,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1582,27 +1436,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1767,21 +1600,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1796,15 +1614,6 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/express": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "express": "^5.2.1",
     "zod": "^4.3.6"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import crypto from 'node:crypto';
+import { createMcpExpressApp } from '@modelcontextprotocol/express';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import express from 'express';
 
 import { registerProfileTools } from './tools/profile.js';
@@ -47,38 +47,31 @@ function authMiddleware(
 }
 
 async function startHttpServer() {
-  const app = express();
-  app.use(express.json());
+  // host '0.0.0.0' because Railway routes to the container from outside. Note
+  // this also means createMcpExpressApp does NOT auto-apply its DNS-rebinding
+  // protection, which it only does for 127.0.0.1 / localhost / ::1. That
+  // matches the behaviour of the previous plain-Express setup, which validated
+  // no hosts either; the endpoint's real gate is the Bearer check below.
+  // Tightening it with allowedHosts is a separate decision, not part of a
+  // transport migration.
+  const app = createMcpExpressApp({ host: '0.0.0.0' });
 
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
   });
 
-  const sessions = new Map<string, StreamableHTTPServerTransport>();
-
-  app.all('/mcp', authMiddleware, async (req, res) => {
-    const existingSessionId = req.headers['mcp-session-id'] as string | undefined;
-
-    if (existingSessionId && sessions.has(existingSessionId)) {
-      const transport = sessions.get(existingSessionId)!;
-      await transport.handleRequest(req, res, req.body);
-      return;
-    }
-
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => crypto.randomUUID(),
-    });
-    const sessionServer = createServer();
-    await sessionServer.connect(transport);
-
-    await transport.handleRequest(req, res, req.body);
-
-    const newSessionId = res.getHeader('mcp-session-id') as string | undefined;
-    if (newSessionId) {
-      sessions.set(newSessionId, transport);
-      transport.onclose = () => sessions.delete(newSessionId);
-    }
-  });
+  // The whole session layer this replaced is gone. It was a Map keyed by the
+  // mcp-session-id header, a UUID generator, one McpServer kept alive per
+  // session, and an onclose handler to evict it. Under the 2026-07-28 spec
+  // Mcp-Session-Id is retired (SEP-2567) and createMcpHandler builds a fresh
+  // server per request instead.
+  //
+  // The practical consequence is not tidiness: that Map was in-memory, so
+  // sessions pinned to one container and the service could not be scaled to a
+  // second replica without breaking clients mid-conversation. It can now.
+  const handler = createMcpHandler(() => createServer());
+  const node = toNodeHandler(handler);
+  app.all('/mcp', authMiddleware, (req, res) => void node(req, res, req.body));
 
   const port = process.env.PORT || 3000;
   app.listen(port, () => {
@@ -87,9 +80,9 @@ async function startHttpServer() {
 }
 
 async function startStdioServer() {
-  const server = createServer();
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // v2 replaces `server.connect(new StdioServerTransport())` with a factory;
+  // serveStdio owns the transport and the server lifecycle.
+  serveStdio(() => createServer());
   console.error('Open Collective MCP Server running on stdio');
 }
 

--- a/src/tools/financial.ts
+++ b/src/tools/financial.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { GET_BALANCE, LIST_TRANSACTIONS, LIST_EXPENSES } from '../queries/financial.js';

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { LIST_MEMBERS } from '../queries/members.js';

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { GET_COLLECTIVE, EDIT_ACCOUNT, UPDATE_SOCIAL_LINKS } from '../queries/profile.js';

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { LIST_PROJECTS, GET_PROJECT, CREATE_PROJECT, EDIT_PROJECT } from '../queries/projects.js';

--- a/src/tools/tiers.ts
+++ b/src/tools/tiers.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { LIST_TIERS, CREATE_TIER, EDIT_TIER } from '../queries/tiers.js';

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { gql } from '../graphql.js';
 import { LIST_UPDATES, GET_UPDATE, CREATE_UPDATE, EDIT_UPDATE, PUBLISH_UPDATE } from '../queries/updates.js';


### PR DESCRIPTION
Addresses #12. **98 insertions, 288 deletions** — most of it removal.

## The substantive change is that session handling is gone

The old HTTP path kept an in-memory `Map<string, StreamableHTTPServerTransport>` keyed by the `mcp-session-id` header, a UUID generator, one `McpServer` held open per session, and an `onclose` handler to evict it. Under the 2026-07-28 spec that header is retired ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)) and `createMcpHandler` builds a fresh server per request.

**That Map was not just clutter.** It lived in process memory, so sessions pinned to a single container and this service could not run a second Railway replica without breaking clients mid-conversation. It can now. That is the actual payoff here, and it is why this server was the strongest candidate of the estate — unlike the stdio ones, where the scalability argument does not apply at all.

## v2 is the package split

`@modelcontextprotocol/sdk` → `@modelcontextprotocol/server` + `/core`, plus `/express` and `/node` for the HTTP path. stdio moves from `server.connect(new StdioServerTransport())` to `serveStdio(factory)`.

**zod was already `^4.3.6` here**, so the version conflict that complicated `Citizen-Infra/community-admin#101` did not arise. Worth noting for the remaining migrations: that one is only a problem where a `^3.x` range is still pinned.

## One behavioural note worth reviewing

`createMcpExpressApp` auto-applies DNS rebinding protection only for `127.0.0.1`/`localhost`/`::1`. Railway needs `0.0.0.0`, so it logs a warning on boot:

```
Warning: Server is binding to 0.0.0.0 without DNS rebinding protection.
Consider using the allowedHosts option ... or use authentication to protect your server.
```

Expected, and it matches pre-migration behaviour — the old plain-Express setup validated no hosts either. The gate on `/mcp` remains the `API_KEY` Bearer check, which is the second thing that warning suggests. Tightening with `allowedHosts` is a security decision, not part of a transport migration, so I left it and documented it.

## Verification

No test suite in this repo, so: build plus both transports exercised directly.

| Check | Result |
|---|---|
| `npm run build` (`tsc`) | clean |
| stdio, bare `tools/list`, no `initialize` | 19 tools |
| HTTP, `tools/list`, no `initialize`, no session id | 19 tools |
| HTTP, second request, still no session id | 200 |
| HTTP, no `Authorization` | 401 |
| `GET /health` | `{"status":"ok"}` |

The second HTTP request succeeding without a session is the point: it demonstrates statelessness rather than asserting it. On v1 the first request would have had to be `initialize`.

## Deliberately not included

The **19 raw-shape `inputSchema` declarations** across `src/tools/`. v2 auto-wraps them and TypeScript accepts them through a deprecated overload, so the build is clean and nothing is broken. Wrapping them in `z.object()` is a separate mechanical pass over six files, and with no test suite here I would rather not do 19 hand edits in the same change that rewrites the transport. Left on #12, and noted in `CLAUDE.md` so the next person adding a tool knows which form they are copying.

## Docs

`CLAUDE.md` described the session map and said the factory runs once per session. Both were true and are now wrong, so they are corrected in the same commit rather than left to rot.
