### PR TITLE
refactor(tools): wrap inputSchema in z.object

### DIFF
--- a/src/tools/financial.ts
+++ b/src/tools/financial.ts
@@ -7,9 +7,9 @@ export function registerFinancialTools(server: McpServer): void {
   server.registerTool('oc-get-balance', {
     title: 'Get Balance',
     description: 'Get current balance and financial summary for a collective.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
-    },
+    }),
   }, async ({ collective }) => {
     const data = await gql<{ account: Record<string, unknown> }>(GET_BALANCE, { slug: collective });
     return {
@@ -20,14 +20,14 @@ export function registerFinancialTools(server: McpServer): void {
   server.registerTool('oc-list-transactions', {
     title: 'List Transactions',
     description: 'List transactions for a collective with optional filters.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       limit: z.number().optional().describe('Max results (default 20)'),
       offset: z.number().optional().describe('Offset for pagination'),
       type: z.enum(['DEBIT', 'CREDIT']).optional().describe('Filter by type'),
       dateFrom: z.string().optional().describe('Start date (ISO 8601)'),
       dateTo: z.string().optional().describe('End date (ISO 8601)'),
-    },
+    }),
   }, async ({ collective, limit, offset, type, dateFrom, dateTo }) => {
     const vars: Record<string, unknown> = {
       account: [{ slug: collective }],
@@ -50,7 +50,7 @@ export function registerFinancialTools(server: McpServer): void {
   server.registerTool('oc-list-expenses', {
     title: 'List Expenses',
     description: 'List expenses for a collective with optional filters. Statuses: DRAFT, PENDING, APPROVED, PAID, REJECTED, etc.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       limit: z.number().optional().describe('Max results (default 20)'),
       offset: z.number().optional().describe('Offset for pagination'),
@@ -58,7 +58,7 @@ export function registerFinancialTools(server: McpServer): void {
         .describe('Filter by status'),
       dateFrom: z.string().optional().describe('Start date (ISO 8601)'),
       dateTo: z.string().optional().describe('End date (ISO 8601)'),
-    },
+    }),
   }, async ({ collective, limit, offset, status, dateFrom, dateTo }) => {
     const vars: Record<string, unknown> = {
       account: { slug: collective },

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -7,13 +7,13 @@ export function registerMemberTools(server: McpServer): void {
   server.registerTool('oc-list-members', {
     title: 'List Members',
     description: 'List members/contributors of a collective. Roles: ADMIN, BACKER, CONTRIBUTOR, HOST, MEMBER, FOLLOWER.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       limit: z.number().optional().describe('Max results (default 50)'),
       offset: z.number().optional().describe('Offset for pagination'),
       role: z.array(z.enum(['ADMIN', 'BACKER', 'CONTRIBUTOR', 'HOST', 'MEMBER', 'FOLLOWER', 'ATTENDEE', 'ACCOUNTANT']))
         .optional().describe('Filter by role(s)'),
-    },
+    }),
   }, async ({ collective, limit, offset, role }) => {
     const vars: Record<string, unknown> = {
       slug: collective,

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -7,9 +7,9 @@ export function registerProfileTools(server: McpServer): void {
   server.registerTool('oc-get-collective', {
     title: 'Get Collective',
     description: 'Read an Open Collective profile — name, description, image, social links, balance, settings.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug (e.g., "harmonica" or "citizen-infra")'),
-    },
+    }),
   }, async ({ collective }) => {
     const data = await gql<{ account: Record<string, unknown> }>(GET_COLLECTIVE, { slug: collective });
     return {
@@ -20,14 +20,14 @@ export function registerProfileTools(server: McpServer): void {
   server.registerTool('oc-edit-collective', {
     title: 'Edit Collective',
     description: 'Update collective profile fields — name, description, long description, image URL, tags.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       name: z.string().optional().describe('New name'),
       description: z.string().optional().describe('Short description'),
       longDescription: z.string().optional().describe('Long description (HTML)'),
       image: z.string().optional().describe('Image URL'),
       tags: z.array(z.string()).optional().describe('Tags'),
-    },
+    }),
   }, async ({ collective, ...fields }) => {
     const { account } = await gql<{ account: { id: string } }>(
       `query { account(slug: "${collective}") { id } }`,
@@ -48,13 +48,13 @@ export function registerProfileTools(server: McpServer): void {
   server.registerTool('oc-update-social-links', {
     title: 'Update Social Links',
     description: 'Set social links on a collective. Replaces all existing links. Types: WEBSITE, GITHUB, TWITTER, LINKEDIN, DISCORD, BLUESKY, MASTODON, YOUTUBE, FACEBOOK, INSTAGRAM, TIKTOK, SLACK, etc.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       links: z.array(z.object({
         type: z.string().describe('Link type (e.g., WEBSITE, GITHUB, TWITTER)'),
         url: z.string().describe('URL'),
       })).describe('Social links to set'),
-    },
+    }),
   }, async ({ collective, links }) => {
     const data = await gql<{ updateSocialLinks: unknown[] }>(UPDATE_SOCIAL_LINKS, {
       account: { slug: collective },

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -7,9 +7,9 @@ export function registerProjectTools(server: McpServer): void {
   server.registerTool('oc-list-projects', {
     title: 'List Projects',
     description: 'List projects under a collective.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Parent collective slug'),
-    },
+    }),
   }, async ({ collective }) => {
     const data = await gql<{ account: { childrenAccounts: { totalCount: number; nodes: unknown[] } } }>(
       LIST_PROJECTS, { slug: collective },
@@ -25,9 +25,9 @@ export function registerProjectTools(server: McpServer): void {
   server.registerTool('oc-get-project', {
     title: 'Get Project',
     description: 'Read a single project by its slug.',
-    inputSchema: {
+    inputSchema: z.object({
       projectSlug: z.string().describe('Project slug (e.g., "ai-agents-avatars")'),
-    },
+    }),
   }, async ({ projectSlug }) => {
     const data = await gql<{ account: Record<string, unknown> }>(GET_PROJECT, { slug: projectSlug });
     return {
@@ -38,13 +38,13 @@ export function registerProjectTools(server: McpServer): void {
   server.registerTool('oc-create-project', {
     title: 'Create Project',
     description: 'Create a new project under a collective.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Parent collective slug'),
       name: z.string().describe('Project name'),
       slug: z.string().describe('Project slug (URL-friendly)'),
       description: z.string().describe('Short description'),
       tags: z.array(z.string()).optional().describe('Tags'),
-    },
+    }),
   }, async ({ collective, name, slug, description, tags }) => {
     const input: Record<string, unknown> = { name, slug, description };
     if (tags !== undefined) input.tags = tags;
@@ -61,13 +61,13 @@ export function registerProjectTools(server: McpServer): void {
   server.registerTool('oc-edit-project', {
     title: 'Edit Project',
     description: 'Update a project (name, description, tags). Uses editAccount internally.',
-    inputSchema: {
+    inputSchema: z.object({
       projectSlug: z.string().describe('Project slug'),
       name: z.string().optional().describe('New name'),
       description: z.string().optional().describe('New short description'),
       longDescription: z.string().optional().describe('New long description (HTML)'),
       tags: z.array(z.string()).optional().describe('New tags'),
-    },
+    }),
   }, async ({ projectSlug, ...fields }) => {
     const { account } = await gql<{ account: { id: string } }>(
       `query { account(slug: "${projectSlug}") { id } }`,

--- a/src/tools/tiers.ts
+++ b/src/tools/tiers.ts
@@ -7,9 +7,9 @@ export function registerTierTools(server: McpServer): void {
   server.registerTool('oc-list-tiers', {
     title: 'List Tiers',
     description: 'List contribution tiers for a collective. Includes stats, available quantity, and full configuration.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
-    },
+    }),
   }, async ({ collective }) => {
     const data = await gql<{ account: { tiers: { totalCount: number; nodes: unknown[] } } }>(
       LIST_TIERS, { slug: collective },
@@ -25,7 +25,7 @@ export function registerTierTools(server: McpServer): void {
   server.registerTool('oc-create-tier', {
     title: 'Create Tier',
     description: 'Create a new contribution tier. Types: TIER, MEMBERSHIP, DONATION, TICKET, SERVICE, PRODUCT. Frequencies: MONTHLY, YEARLY, ONETIME, FLEXIBLE.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       name: z.string().describe('Tier name'),
       type: z.enum(['TIER', 'MEMBERSHIP', 'DONATION', 'TICKET', 'SERVICE', 'PRODUCT']).describe('Tier type'),
@@ -43,7 +43,7 @@ export function registerTierTools(server: McpServer): void {
       useStandalonePage: z.boolean().optional().describe('Use a standalone page for this tier'),
       invoiceTemplate: z.string().optional().describe('Custom invoice template'),
       singleTicket: z.boolean().optional().describe('Single ticket mode (for TICKET type)'),
-    },
+    }),
   }, async ({ collective, name, type, amountType, frequency, amountInCents, currency, description, longDescription, button, goalInCents, presets, minimumAmountInCents, maxQuantity, useStandalonePage, invoiceTemplate, singleTicket }) => {
     const cur = currency ?? 'GBP';
     const tier: Record<string, unknown> = { name, type, amountType, frequency };
@@ -71,7 +71,7 @@ export function registerTierTools(server: McpServer): void {
   server.registerTool('oc-edit-tier', {
     title: 'Edit Tier',
     description: 'Update an existing contribution tier.',
-    inputSchema: {
+    inputSchema: z.object({
       id: z.string().describe('Tier ID'),
       name: z.string().optional().describe('New name'),
       description: z.string().optional().describe('New short description'),
@@ -87,7 +87,7 @@ export function registerTierTools(server: McpServer): void {
       useStandalonePage: z.boolean().optional().describe('Use a standalone page for this tier'),
       invoiceTemplate: z.string().optional().describe('Custom invoice template'),
       singleTicket: z.boolean().optional().describe('Single ticket mode'),
-    },
+    }),
   }, async ({ id, name, description, longDescription, button, videoUrl, amountInCents, currency, goalInCents, presets, minimumAmountInCents, maxQuantity, useStandalonePage, invoiceTemplate, singleTicket }) => {
     const cur = currency ?? 'GBP';
     const tier: Record<string, unknown> = { id };

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -7,11 +7,11 @@ export function registerUpdateTools(server: McpServer): void {
   server.registerTool('oc-list-updates', {
     title: 'List Updates',
     description: 'List updates/posts for an Open Collective page.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       limit: z.number().optional().describe('Max results (default 10)'),
       offset: z.number().optional().describe('Offset for pagination'),
-    },
+    }),
   }, async ({ collective, limit, offset }) => {
     const data = await gql<{ account: { updates: { totalCount: number; nodes: unknown[] } } }>(
       LIST_UPDATES, { slug: collective, limit: limit ?? 10, offset: offset ?? 0 },
@@ -27,10 +27,10 @@ export function registerUpdateTools(server: McpServer): void {
   server.registerTool('oc-get-update', {
     title: 'Get Update',
     description: 'Read a single update by its slug. Returns full HTML content.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       updateSlug: z.string().describe('Update slug (e.g., "harmonica-2025-year-in-review")'),
-    },
+    }),
   }, async ({ collective, updateSlug }) => {
     const data = await gql<{ account: { updates: { nodes: Array<{ slug: string } & Record<string, unknown>> } } }>(
       GET_UPDATE, { slug: collective },
@@ -49,13 +49,13 @@ export function registerUpdateTools(server: McpServer): void {
   server.registerTool('oc-create-update', {
     title: 'Create Update',
     description: 'Create a draft update on a collective. Use oc-publish-update to publish it.',
-    inputSchema: {
+    inputSchema: z.object({
       collective: z.string().describe('Collective slug'),
       title: z.string().describe('Update title'),
       html: z.string().describe('Update body (HTML)'),
       isPrivate: z.boolean().optional().describe('Private update (default false)'),
       isChangelog: z.boolean().optional().describe('Mark as changelog (default false)'),
-    },
+    }),
   }, async ({ collective, title, html, isPrivate, isChangelog }) => {
     const input: Record<string, unknown> = {
       account: { slug: collective },
@@ -74,12 +74,12 @@ export function registerUpdateTools(server: McpServer): void {
   server.registerTool('oc-edit-update', {
     title: 'Edit Update',
     description: 'Modify an existing update (title, body, visibility).',
-    inputSchema: {
+    inputSchema: z.object({
       id: z.string().describe('Update ID'),
       title: z.string().optional().describe('New title'),
       html: z.string().optional().describe('New body (HTML)'),
       isPrivate: z.boolean().optional().describe('Set private/public'),
-    },
+    }),
   }, async ({ id, title, html, isPrivate }) => {
     const input: Record<string, unknown> = { id };
     if (title !== undefined) input.title = title;
@@ -95,11 +95,11 @@ export function registerUpdateTools(server: McpServer): void {
   server.registerTool('oc-publish-update', {
     title: 'Publish Update',
     description: 'Publish a draft update. Optionally notify an audience.',
-    inputSchema: {
+    inputSchema: z.object({
       id: z.string().describe('Update ID'),
       notificationAudience: z.enum(['ALL', 'COLLECTIVE_ADMINS', 'FINANCIAL_CONTRIBUTORS', 'NO_ONE']).optional()
         .describe('Who to notify (default: no notification)'),
-    },
+    }),
   }, async ({ id, notificationAudience }) => {
     const data = await gql<{ publishUpdate: Record<string, unknown> }>(
       PUBLISH_UPDATE, { id, notificationAudience },


### PR DESCRIPTION
Closes #12. The last piece — #13 did the transport, this does the schemas.

All 19 tool registrations across six files used the raw-shape form:

```ts
inputSchema: { collective: z.string().describe('...') }
```

v2 auto-wraps that and the types accept it through a deprecated overload, so nothing was broken. But the SDK types say "Wrap with `z.object({...})` instead", it is in scope for #12, and the raw shape is what the next new tool gets copied from.

## Applied mechanically, after checking it was safe to

A brace-matching transform rather than 19 hand edits, which is where a slip would come from. Two preconditions verified first: no `describe()` string contains a brace (which would break brace matching), and every file already imports `z`.

## The verification that matters

The real risk is not a build failure, it is a **silent change to the emitted JSON Schema** — that is the tool contract, and clients would break without anything here going red.

So I captured `tools/list` from a running build of each version and diffed them:

| | raw shape | wrapped |
|---|---|---|
| bytes | 19,390 | 19,390 |
| tools | 19 | 19 |
| diff | **identical** | |

Checked the byte counts explicitly rather than trusting the `diff` verdict, because two empty captures also diff clean and that would have read as a pass.

`npm run build` clean. This repo has no test suite, so build plus that comparison is the gate.
